### PR TITLE
Compiler warnings: perform appropriate casts

### DIFF
--- a/src/Dump.cpp
+++ b/src/Dump.cpp
@@ -6,18 +6,24 @@ unsigned char memBytePgm(const void* x) {return pgm_read_byte(x);}
 void dump(Print& out,void const*at,int sz,unsigned char (*memByte)(const void*)) {
   while(sz>0) {
     out.print("0x");
-    out.print(at<0x10?"000":at<0x100?"00":at<0x1000?"0":"");
+    out.print((unsigned long)at < 0x10 ? "000" : (unsigned long)at<0x100 ? "00" : (unsigned long)at<0x1000 ? "0" : "");
     out.print((unsigned long)at,HEX);
     out.print(": ");
     for(int c=0;c<16;c++) {
       if (c==8) out.write(' ');
       if (sz-c>0) {
-        unsigned char v=memByte(at+c);
+        // Because ISO C forbids `void*` arithmetic, we have to do some funky casting
+        void *memAddress = (void *)((int)at + c);
+        
+        unsigned char v = memByte(memAddress);        
         out.write(v>=32&&v<='z'?v:'.');
       } else out.write(' ');
     }
     out.write(' ');
-    for(int c=0;c<16&&sz;c++,sz--,at+=1) {
+    for (int c=0; c<16 && sz; c++, sz--) {
+      // Because ISO C forbids `void*` arithmetic, we have to do some funky casting
+      at = (void *)((int)at + 1);
+      
       if (c==8) out.write(' ');
       unsigned char v=memByte(at);
       out.print(v<16?"0":"");


### PR DESCRIPTION
This library is awesome, it should be a standard part of Arduino. It makes debugging ridiculously easy, compared to standard ways.

I did run into one problem, though, and that's that ANSI-C forbids certain types of void operations and comparisons. This PR resolves the compiler warnings, allowing the code to be compiled with `-Werror`.